### PR TITLE
Removed blank spaces from getFbDetail url

### DIFF
--- a/src/auth-services.service.ts
+++ b/src/auth-services.service.ts
@@ -106,7 +106,7 @@ function fbLogin(resolve, reject) {
     reject(error);
   }
   function getFbDetail(response) {
-    facebookConnectPlugin.api(response.authResponse.userID + "/?fields=id,first_name, last_name, picture, email&acess_token=" + response.authResponse.accessToken, [],
+    facebookConnectPlugin.api(response.authResponse.userID + "/?fields=id,first_name,last_name,picture,email&acess_token=" + response.authResponse.accessToken, [],
         function (result) {
           result.access_token = response.authResponse.accessToken;
           result.socialType = SocialTypes.facebook;


### PR DESCRIPTION
The blank spaces in the **getFbDetails** url cause an error on **ios**, even though android ignores these errors:

```

Graph Path = 736575700014181/?fields=id,first_name, last_name, picture, email&acess_token=<ACCESS_TOKEN>

 Task <FA71A92E-3196-47D0-9363-C0CAF970B308>.<1> finished with error - code: -1002
2018-11-19 18:00:41.587382+0200 Skills1[948:613847] Finished GraphAPI request
2018-11-19 18:00:41.653597+0200 Skills1[948:613847] There was an error making the graph call.
```